### PR TITLE
Fixing memory leak on low-power devices

### DIFF
--- a/func_vpr.py
+++ b/func_vpr.py
@@ -659,7 +659,7 @@ def process_dino_ft_to_h5(h5FullPath,cfg,ims,models,device = "cuda",dataDir="./"
                 imname, im = i, ims[i][rmin:,:,:]
             im_p, ift_dino = process_single_DINO(cfg,im,models,device)
             grp = f.create_group(f"{imname}")
-            grp.create_dataset("ift_dino", data=ift_dino.detach().cpu().numpy())
+            grp.create_dataset("ift_dino", data=ift_dino.detach().cpu().numpy(), chunks=True)
 
 def process_SAM_to_h5(h5FullPath,cfg,ims,models,device="cuda",dataDir="./"):
     rmin = cfg['rmin']

--- a/place_rec_SAM_DINO.py
+++ b/place_rec_SAM_DINO.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 import numpy as np
 
 import argparse
-import func_vpr 
+import func_vpr
 from place_rec_global_config import datasets, workdir_data
 
 
@@ -26,41 +26,44 @@ def set_extraction_method(method):
     else:
         raise ValueError("Invalid method. Choose from 'DINO', 'SAM', or 'FastSAM'.")
 
-if __name__=="__main__":
-    parser = argparse.ArgumentParser(description='SAM/DINO/FastSAM extraction for Any Dataset. See place_rec_global_config.py to see how to give arguments.')
-    parser.add_argument('--dataset', required=True, help='Dataset name') # baidu, pitts etc
-    parser.add_argument('--method', required=True, choices=['DINO', 'SAM'], help="Choose extraction method: 'DINO', 'SAM'")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='SAM/DINO/FastSAM extraction for Any Dataset. See place_rec_global_config.py to see how to give arguments.')
+    parser.add_argument('--dataset', required=True, help='Dataset name')  # baidu, pitts etc
+    parser.add_argument('--method', required=True, choices=['DINO', 'SAM'],
+                        help="Choose extraction method: 'DINO', 'SAM'")
 
     args = parser.parse_args()
 
     DINO_extraction, SAM_extraction, FastSAM_extraction = set_extraction_method(args.method)
 
-
-    mask_full_resolution = False #DINO always full resolution
+    mask_full_resolution = False  # DINO always full resolution
 
     # Load dataset and experiment configurations
     dataset_config = datasets.get(args.dataset, {})
     if not dataset_config:
         raise ValueError(f"Dataset '{args.dataset}' not found in configuration.")
 
-
     print(dataset_config)
 
     cfg = dataset_config['cfg']
     # mask width and height: half if mask_full_resolution is False, else True
-    if mask_full_resolution: #DINO always full resolution
-        width_SAM, height_SAM =  cfg['desired_width'], cfg['desired_height']
-        width_DINO, height_DINO =  cfg['desired_width'], cfg['desired_height']
+    if mask_full_resolution:  # DINO always full resolution
+        width_SAM, height_SAM = cfg['desired_width'], cfg['desired_height']
+        width_DINO, height_DINO = cfg['desired_width'], cfg['desired_height']
         print(f"Note: The dimensions being used for SAM and DINO extraction are both {width_SAM}x{height_SAM} pixels.")
     else:
-        if args.dataset == "AmsterTime": # use full resolution for AmsterTime as original res is itself small
-            width_SAM, height_SAM =  cfg['desired_width'], cfg['desired_height']
-            width_DINO, height_DINO =  cfg['desired_width'], cfg['desired_height']
-            print(f"Note: The dimensions being used for SAM and DINO extraction are both {width_SAM}x{height_SAM} pixels.")
+        if args.dataset == "AmsterTime":  # use full resolution for AmsterTime as original res is itself small
+            width_SAM, height_SAM = cfg['desired_width'], cfg['desired_height']
+            width_DINO, height_DINO = cfg['desired_width'], cfg['desired_height']
+            print(
+                f"Note: The dimensions being used for SAM and DINO extraction are both {width_SAM}x{height_SAM} pixels.")
         else:
-            width_SAM, height_SAM =  int(0.5 * cfg['desired_width']), int(0.5 * cfg['desired_height'])
-            width_DINO, height_DINO =  cfg['desired_width'], cfg['desired_height']
-            print(f"Note: The dimensions being used for SAM extraction are {width_SAM}x{height_SAM} pixels and for DINO extraction are {width_DINO}x{height_DINO} pixels.")
+            width_SAM, height_SAM = int(0.5 * cfg['desired_width']), int(0.5 * cfg['desired_height'])
+            width_DINO, height_DINO = cfg['desired_width'], cfg['desired_height']
+            print(
+                f"Note: The dimensions being used for SAM extraction are {width_SAM}x{height_SAM} pixels and for DINO extraction are {width_DINO}x{height_DINO} pixels.")
 
     workdir = f'{workdir_data}/{args.dataset}/out'
     os.makedirs(workdir, exist_ok=True)
@@ -74,13 +77,17 @@ if __name__=="__main__":
     if FastSAM_extraction:
         sam_checkpoint = f"{workdir_data}/models/FastSAM/FastSAM-x.pt"
         list_all = [
-            {"dataPath": dataPath1_r, "h5FullPathDINO": f"{workdir}/{args.dataset}_r_dino_{width_DINO}.h5",  "h5FullPathSAM": f"{workdir}/{args.dataset}_r_FastSAM_masks_{width_SAM}.h5"},
-            {"dataPath": dataPath2_q, "h5FullPathDINO": f"{workdir}/{args.dataset}_q_dino_{width_DINO}.h5", "h5FullPathSAM": f"{workdir}/{args.dataset}_q_FastSAM_masks_{width_SAM}.h5"} ]
+            {"dataPath": dataPath1_r, "h5FullPathDINO": f"{workdir}/{args.dataset}_r_dino_{width_DINO}.h5",
+             "h5FullPathSAM": f"{workdir}/{args.dataset}_r_FastSAM_masks_{width_SAM}.h5"},
+            {"dataPath": dataPath2_q, "h5FullPathDINO": f"{workdir}/{args.dataset}_q_dino_{width_DINO}.h5",
+             "h5FullPathSAM": f"{workdir}/{args.dataset}_q_FastSAM_masks_{width_SAM}.h5"}]
     else:
         sam_checkpoint = f"{workdir_data}/models/segment-anything/sam_vit_h_4b8939.pth"
         list_all = [
-            {"dataPath": dataPath1_r, "h5FullPathDINO": f"{workdir}/{args.dataset}_r_dino_{width_DINO}.h5", "h5FullPathSAM": f"{workdir}/{args.dataset}_r_masks_{width_SAM}.h5"},
-            {"dataPath": dataPath2_q, "h5FullPathDINO": f"{workdir}/{args.dataset}_q_dino_{width_DINO}.h5", "h5FullPathSAM": f"{workdir}/{args.dataset}_q_masks_{width_SAM}.h5"} ]
+            {"dataPath": dataPath1_r, "h5FullPathDINO": f"{workdir}/{args.dataset}_r_dino_{width_DINO}.h5",
+             "h5FullPathSAM": f"{workdir}/{args.dataset}_r_masks_{width_SAM}.h5"},
+            {"dataPath": dataPath2_q, "h5FullPathDINO": f"{workdir}/{args.dataset}_q_dino_{width_DINO}.h5",
+             "h5FullPathSAM": f"{workdir}/{args.dataset}_q_masks_{width_SAM}.h5"}]
 
     if FastSAM_extraction:
         raise NotImplementedError("FastSAM extraction is not implemented in this script. To be updated soon.")
@@ -100,49 +107,51 @@ if __name__=="__main__":
     #         func_vpr.process_SAM_to_h5_FastSAM(h5FullPathSAM, cfg_sam,ims,FastSAM,dataDir=dataPath)
     #         print("\n \n FastSAM EXTRACTED DONE \n \n")
 
-
     if DINO_extraction:
+
+        cfg_dino = {"desired_width": width_DINO, "desired_height": height_DINO, "detect": 'dino', "use_sam": True,
+                    "class_threshold": 0.9,
+                    "desired_feature": 0, "query_type": 'text', "sort_by": 'area', "use_16bit": False,
+                    "use_cuda": True,
+                    "dino_strides": 4, "use_traced_model": False,
+                    "rmin": 0, "DAStoreFull": False, "dinov2": True, "wrap": False,
+                    "resize": True}  # robohop specifc params
+
+        print("DINO extraction started...")
+        dino = func_vpr.loadDINO(cfg_dino, device="cuda")
 
         for iter_dict in list_all:
             dataPath = iter_dict["dataPath"]
             ims = natsorted(os.listdir(f'{dataPath}'))
             ims = ims[ims_sidx:ims_eidx][::ims_step]
-        
+
             h5FullPathDINO = iter_dict["h5FullPathDINO"]
-            cfg_dino = { "desired_width": width_DINO, "desired_height": height_DINO, "detect": 'dino', "use_sam": True, "class_threshold": 0.9, \
-                "desired_feature": 0, "query_type": 'text', "sort_by": 'area', "use_16bit": False, "use_cuda": True,\
-                        "dino_strides": 4, "use_traced_model": False, 
-                        "rmin":0, "DAStoreFull":False, "dinov2": True, "wrap":False, "resize": True} # robohop specifc params
-        
-            print("DINO extraction started...")
-            dino = func_vpr.loadDINO(cfg_dino, device="cuda")
-            func_vpr.process_dino_ft_to_h5(h5FullPathDINO,cfg_dino,ims,dino,dataDir=dataPath)
+            func_vpr.process_dino_ft_to_h5(h5FullPathDINO, cfg_dino, ims, dino, dataDir=dataPath)
 
         print("\n \n DINO EXTRACTED DONE \n \n ")
 
     if SAM_extraction:
+        cfg_sam = {"desired_width": width_SAM, "desired_height": height_SAM, "detect": 'dino', "use_sam": True,
+                   "class_threshold": 0.9,
+                   "desired_feature": 0, "query_type": 'text', "sort_by": 'area', "use_16bit": False,
+                   "use_cuda": True,
+                   "dino_strides": 4, "use_traced_model": False,
+                   "rmin": 0, "DAStoreFull": False, "dinov2": True, "wrap": False,
+                   "resize": True}  # robohop specifc params
+
+        print("SAM extraction started...")
+        SAM = func_vpr.loadSAM(sam_checkpoint, cfg_sam, device="cuda")
+
         for iter_dict in list_all:
             dataPath = iter_dict["dataPath"]
             ims = natsorted(os.listdir(f'{dataPath}'))
             ims = ims[ims_sidx:ims_eidx][::ims_step]
 
             h5FullPathSAM = iter_dict["h5FullPathSAM"]
-            cfg_sam = { "desired_width": width_SAM, "desired_height": height_SAM, "detect": 'dino', "use_sam": True, "class_threshold": 0.9, \
-                "desired_feature": 0, "query_type": 'text', "sort_by": 'area', "use_16bit": False, "use_cuda": True,\
-                        "dino_strides": 4, "use_traced_model": False, 
-                        "rmin":0, "DAStoreFull":False, "dinov2": True, "wrap":False, "resize": True} # robohop specifc params
-
-            print("SAM extraction started...")
-            SAM = func_vpr.loadSAM(sam_checkpoint,cfg_sam, device="cuda")
-            func_vpr.process_SAM_to_h5(h5FullPathSAM, cfg_sam,ims,SAM,dataDir=dataPath)
-            #sanity check for resizing
+            func_vpr.process_SAM_to_h5(h5FullPathSAM, cfg_sam, ims, SAM, dataDir=dataPath)
+            # sanity check for resizing
             # f = h5py.File(h5FullPathSAM,'r')
             # keys = list(f.keys())
             # print(f[keys[0]]['masks']['21']['segmentation'])
 
         print("\n \n SAM EXTRACTED DONE \n \n ")
-
-
-
-
-


### PR DESCRIPTION
Thanks for your wonderful repository segVlad!

When working with your repository, I encountered a problem with memory overflow and leakage due to loading the same model in a loop and storing all extracted vectors in RAM. With a large dataset, this error is critical.

The following fixes are suggested:

#### 1. Added `chunks = True` to avoid RAM overflow on large datasets or low-power devices
```python
grp.create_dataset ("ift_dino", data=ift_dino.detach().cpu().numpy(), chunks=True)
```
#### 2. The model configuration dict and model load function have been moved above the dataset loop to avoid re-initialization and memory overflow when using large models.
```python
if SAM_extraction:
        cfg_sam = {"desired_width": width_SAM, "desired_height": height_SAM, "detect": 'dino', "use_sam": True,
                   "class_threshold": 0.9,
                   "desired_feature": 0, "query_type": 'text', "sort_by": 'area', "use_16bit": False,
                   "use_cuda": True,
                   "dino_strides": 4, "use_traced_model": False,
                   "rmin": 0, "DAStoreFull": False, "dinov2": True, "wrap": False,
                   "resize": True}  # robohop specifc params

        print("SAM extraction started...")
        SAM = func_vpr.loadSAM(sam_checkpoint, cfg_sam, device="cuda")

        for iter_dict in list_all:
            ...
 ```